### PR TITLE
cmake: Fix variable substitution in pkg-config

### DIFF
--- a/gr-qtgui/gnuradio-qtgui.pc.in
+++ b/gr-qtgui/gnuradio-qtgui.pc.in
@@ -7,5 +7,5 @@ Name: gnuradio-qtgui
 Description: GNU Radio blocks for QT GUI
 Requires: gnuradio-runtime
 Version: @LIBVER@
-Libs: -L${libdir} -lgnuradio-qtgui ${PC_LIBS_STR}
-Cflags: -I${includedir} -I${QWT_INCLUDE_DIRS} -I${QT_HEADERS_DIR}
+Libs: -L${libdir} -lgnuradio-qtgui @PC_LIBS_STR@
+Cflags: -I${includedir} -I@QWT_INCLUDE_DIRS@ -I@QT_HEADERS_DIR@


### PR DESCRIPTION
Variable interpolation is done with configure_file(... @ONLY), so use @VAR@ and not ${VAR}.

I do not have a way to test this change but the way it stands now is certainly wrong.

Fixes #3969.